### PR TITLE
WIP: Lots of improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,18 @@ Does
 - Per-project migrations
 - Migration of issues, keeping as much metadata as possible:
   - redmine trackers become tags
+  - redmine categories become tags
   - issues comments are kept and assigned to the right users
   - issues final status (open/closed) are kept along with open/close date (not
     detailed status history)
   - issues assignments are kept
   - issues numbers (ex: `#123`)
   - issues/notes authors
-  - issue/notes original dates, but as comments
-  - relations (although gitlab model for relations is simpler)
+  - issues/notes original dates, but as comments
+  - issue attachements
+  - issue related changesets
+  - issues custom fields (if specified) 
+  - relations including children and parent (although gitlab model for relations is simpler)
 - Migration of Versions/Roadmaps keeping:
   - issues composing the version
   - statuses & due dates
@@ -57,7 +61,8 @@ Requires
 - No preexisting issues on gitlab project
 - Already synced users (those required in the project you are migrating)
 
-(It was developed/tested arround redmine 2.5.2, gitlab 8.2.0, python 3.4)
+(Original version was developed/tested around redmine 2.5.2, gitlab 8.2.0, python 3.4)
+(Updated version was developed/tested around redmine 2.1.2, gitlab 8.12.1, python 3.4)
 
 
 Let's go
@@ -123,6 +128,19 @@ Note that your issue titles will be annotated with the original redmine issue
 ID, like *-RM-1186-MR-logging*. This annotation will be used (and removed) by
 the next step.
 
+At least redmine 2.1.2 has no closed_on field, so you have to specify the names of the states which define closed issues. 
+defaults to closed,rejected
+
+    --closed-states closed,rejected,wontfix
+
+If you want to migrate redmine custom fields (as description), you can specify
+
+    --custom-fields Customer,ZendeskIssueId
+ 
+If you're using SSL with self signed cerificates and get an *requests.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:600)* error, you can disable certificate validation with
+
+    --no-verify
+
 ### Migrate Issues ID (iid)
 
 You can retain the issues ID from redmine, **this cannot be done via REST
@@ -131,8 +149,7 @@ API**, thus it requires **direct access to the gitlab machine**.
 So you have to log in the gitlab machine (eg. via SSH), and then issue the
 commad with sufficient rights, from there:
 
-    migrate-rg iid --redmine --redmine-key xxxx --gitlab-key xxxx \
-      https://redmine.example.com/projects/myproject \
+    migrate-rg iid --gitlab-key xxxx \
       http://git.example.com/mygroup/myproject --check
 
 

--- a/redmine_gitlab_migrator/__init__.py
+++ b/redmine_gitlab_migrator/__init__.py
@@ -2,6 +2,10 @@ import logging
 
 import requests
 
+# http://stackoverflow.com/a/28002687/98491 
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
 log = logging.getLogger(__name__)
 
 

--- a/redmine_gitlab_migrator/__init__.py
+++ b/redmine_gitlab_migrator/__init__.py
@@ -10,8 +10,9 @@ log = logging.getLogger(__name__)
 
 
 class APIClient:
-    def __init__(self, api_key):
+    def __init__(self, api_key, verify):
         self.api_key = api_key
+        self.verify = verify
 
     def get_auth_headers(self):
         """ Method to be overloaded by child classes
@@ -25,6 +26,7 @@ class APIClient:
         headers = kwargs.get('headers', {})
         headers.update(self.get_auth_headers())
         _kwargs['headers'] = headers
+        _kwargs['verify'] = self.verify
         return _kwargs
 
     def _req(self, func, *args, **kwargs):

--- a/redmine_gitlab_migrator/commands.py
+++ b/redmine_gitlab_migrator/commands.py
@@ -123,7 +123,7 @@ def perform_migrate_issues(args):
     issues = redmine_project.get_all_issues()
     milestones_index = gitlab_project.get_milestones_index()
     issues_data = (
-        convert_issue(
+        convert_issue(args.redmine_key,
             i, redmine_users_index, gitlab_users_index, milestones_index)
         for i in issues)
 

--- a/redmine_gitlab_migrator/commands.py
+++ b/redmine_gitlab_migrator/commands.py
@@ -65,10 +65,26 @@ def parse_args():
             required=False, action='store_true', default=False,
             help="More output")
 
+        i.add_argument(
+            '--no-verify',
+            required=False, action='store_false', default=True,
+            help="disable SSL certificate verification")
+
+    parser_issues.add_argument(
+        '--closed-states',
+        required=False,
+        help="comma seperated list of redmine states that close an issue, default closed,rejected")
+
+    parser_issues.add_argument(
+        '--custom-fields',
+        required=False,
+        help="comma seperated list of redmine custom filds to migrate")
+
     return parser.parse_args()
 
 
 def check(func, message, redmine_project, gitlab_project):
+    log.info('{}...'.format(message))
     ret = func(redmine_project, gitlab_project)
     if ret:
         log.info('{}... OK'.format(message))
@@ -78,20 +94,26 @@ def check(func, message, redmine_project, gitlab_project):
 
 
 def check_users(redmine_project, gitlab_project):
-    users = redmine_project.get_participants()
+
+    redmine_users = redmine_project.get_participants()
+    gitlab_users = gitlab_project.get_instance().get_all_users()
+
     # Filter out anonymous user
-    nicks = [i['login'] for i in users if i['login'] != '']
-    log.info('Project users are: {}'.format(', '.join(nicks) + ' '))
+    redmine_user_names = [i['login'] for i in redmine_users if i['login'] != '']
+    gitlab_user_names = set([i['username'] for i in gitlab_users])
 
-    return gitlab_project.get_instance().check_users_exist(nicks)
+    log.info('Redmine users are: {}'.format(', '.join(redmine_user_names) + ' '))
+    log.info('GitLab users are: {}'.format(', '.join(gitlab_user_names) + ' '))
 
+    return gitlab_project.get_instance().check_users_exist(redmine_user_names)
 
 def check_no_issue(redmine_project, gitlab_project):
     return len(gitlab_project.get_issues()) == 0
 
 
-def check_no_milestone(redmine_project, gitlab_project):
-    return len(gitlab_project.get_milestones()) == 0
+# check_no_milestone no longer required (milestone will only be created if not exist)
+#def check_no_milestone(redmine_project, gitlab_project):
+#    return len(gitlab_project.get_milestones()) == 0
 
 
 def check_origin_milestone(redmine_project, gitlab_project):
@@ -99,8 +121,17 @@ def check_origin_milestone(redmine_project, gitlab_project):
 
 
 def perform_migrate_issues(args):
-    redmine = RedmineClient(args.redmine_key)
-    gitlab = GitlabClient(args.gitlab_key)
+
+    closed_states = []
+    if (args.closed_states):
+        closed_states = args.closed_states.split(',')
+
+    custom_fields = []
+    if (args.custom_fields):
+        custom_fields = args.custom_fields.split(',')
+
+    redmine = RedmineClient(args.redmine_key, args.no_verify)
+    gitlab = GitlabClient(args.gitlab_key, args.no_verify)
 
     redmine_project = RedmineProject(args.redmine_project_url, redmine)
     gitlab_project = GitlabProject(args.gitlab_project_url, gitlab)
@@ -109,6 +140,9 @@ def perform_migrate_issues(args):
 
     gitlab_users_index = gitlab_instance.get_users_index()
     redmine_users_index = redmine_project.get_users_index()
+    milestones_index = gitlab_project.get_milestones_index()
+    
+    log.debug('GitLab milestones are: {}'.format(', '.join(milestones_index) + ' '))
 
     checks = [
         (check_users, 'Required users presence'),
@@ -118,15 +152,19 @@ def perform_migrate_issues(args):
         check(
             *i, redmine_project=redmine_project, gitlab_project=gitlab_project)
 
-    # Get issues
-
+    # get issues
+    log.info('Getting redmine issues')
     issues = redmine_project.get_all_issues()
-    milestones_index = gitlab_project.get_milestones_index()
+
+    # convert issues
+    log.info('Converting issues')
     issues_data = (
         convert_issue(args.redmine_key,
-            i, redmine_users_index, gitlab_users_index, milestones_index)
+            i, redmine_users_index, gitlab_users_index, milestones_index, closed_states, custom_fields)
         for i in issues)
 
+    # create issues
+    log.info('Creating gitlab issues')
     for data, meta in issues_data:
         if args.check:
             milestone_id = data.get('milestone_id', None)
@@ -142,16 +180,24 @@ def perform_migrate_issues(args):
             log.info('Would create issue "{}" and {} notes.'.format(
                 data['title'],
                 len(meta['notes'])))
-        else:
-            created = gitlab_project.create_issue(data, meta)
-            log.info('#{iid} {title}'.format(**created))
 
+        else:
+
+            try:
+                created = gitlab_project.create_issue(data, meta)
+                log.info('#{iid} {title}'.format(**created))
+            except:
+                log.info('create issue "{}" failed'.format(data['title']))
+                raise
 
 def perform_migrate_iid(args):
     """ Shoud occur after the issues migration
     """
 
-    gitlab = GitlabClient(args.gitlab_key)
+    # access gitlab database with
+    # gitlab-rails dbconsole
+
+    gitlab = GitlabClient(args.gitlab_key, args.no_verify)
     gitlab_project = GitlabProject(args.gitlab_project_url, gitlab)
     gitlab_project_id = gitlab_project.get_id()
 
@@ -179,9 +225,17 @@ def perform_migrate_iid(args):
         exit(1)
 
     if not args.check:
-        sql_cmd = sql.MIGRATE_IID_ISSUES.format(
+
+        # first we change the iid to large values to prevent a
+        # duplicate key value violates unique_constraint "index_issues_on_project_id_and_iid"
+        # KEY (project_id, iid)=(37, 83) already exists
+        sql_cmd1 = sql.UPDATE_IID_ISSUES.format(
             regex=regex_saved_iid, project_id=gitlab_project_id)
-        out = sql.run_query(sql_cmd)
+        out1 = sql.run_query(sql_cmd1)
+  
+        sql_cmd2 = sql.MIGRATE_IID_ISSUES.format(
+            regex=regex_saved_iid, project_id=gitlab_project_id)
+        out2 = sql.run_query(sql_cmd2)
 
         try:
             m = re.match(
@@ -196,14 +250,14 @@ def perform_migrate_iid(args):
 
 
 def perform_migrate_roadmap(args):
-    redmine = RedmineClient(args.redmine_key)
-    gitlab = GitlabClient(args.gitlab_key)
+    redmine = RedmineClient(args.redmine_key, args.no_verify)
+    gitlab = GitlabClient(args.gitlab_key, args.no_verify)
 
     redmine_project = RedmineProject(args.redmine_project_url, redmine)
     gitlab_project = GitlabProject(args.gitlab_project_url, gitlab)
 
     checks = [
-        (check_no_milestone, 'Gitlab project has no pre-existing milestone'),
+        #(check_no_milestone, 'Gitlab project has no pre-existing milestone'),
         (check_origin_milestone, 'Redmine project contains versions'),
     ]
     for i in checks:

--- a/redmine_gitlab_migrator/converters.py
+++ b/redmine_gitlab_migrator/converters.py
@@ -8,15 +8,9 @@ log = logging.getLogger(__name__)
 # Utils
 
 
-def redmine_uid_to_login(redmine_id, redmine_user_index):
-    return redmine_user_index[redmine_id]['login']
-
-
-def redmine_uid_to_gitlab_uid(redmine_id,
-                              redmine_user_index, gitlab_user_index):
-    username = redmine_uid_to_login(redmine_id, redmine_user_index)
-    return gitlab_user_index[username]['id']
-
+def redmine_uid_to_gitlab_user(redmine_id, redmine_user_index, gitlab_user_index):
+    redmine_login = redmine_user_index[redmine_id]['login']
+    return gitlab_user_index[redmine_login]
 
 def convert_attachment(redmine_issue_attachment, redmine_api_key):
     """ Convert a list of redmine attachments to gitlab uploads
@@ -29,13 +23,13 @@ def convert_attachment(redmine_issue_attachment, redmine_api_key):
         'filename': redmine_issue_attachment['filename'],
         'description': redmine_issue_attachment.get('description'),
         'content_url': '{}?key={}'.format(redmine_issue_attachment['content_url'], redmine_api_key),
-        'content_type': redmine_issue_attachment['content_type']
+        'content_type': redmine_issue_attachment.get('content_type', 'application/octet-stream')
     }
 
     return uploads
     
 
-def convert_notes(redmine_issue_journals, redmine_user_index):
+def convert_notes(redmine_issue_journals, redmine_user_index, gitlab_user_index):
     """ Convert a list of redmine journal entries to gitlab notes
 
     Filters out the empty notes (ex: bare status change)
@@ -53,8 +47,8 @@ def convert_notes(redmine_issue_journals, redmine_user_index):
             body = "{}\n\n*(from redmine: written on {})*".format(
                 journal_notes, entry['created_on'][:10])
             try:
-                author = redmine_uid_to_login(
-                    entry['user']['id'], redmine_user_index)
+                author = redmine_uid_to_gitlab_user(
+                    entry['user']['id'], redmine_user_index, gitlab_user_index)['username']
             except KeyError:
                 # In some cases you have anonymous notes, which do not exist in
                 # gitlab.
@@ -80,18 +74,16 @@ def relations_to_string(relations, children, parent_id, issue_id):
             other_issue_id = i['issue_to_id']
         else:
             other_issue_id = i['issue_id']
-        l.append('{} #{}'.format(i['relation_type'], other_issue_id))
+        l.append('  * {} #{}'.format(i['relation_type'], other_issue_id))
 
     for i in children:
-        id = i['id']
-        tracker = i['tracker']
-        
-        l.append('{} #{}'.format('child', id))
+        id = i['id']        
+        l.append('  * {} #{}'.format('child', id))
 
     if parent_id > 0:
-       l.append('{} #{}'.format('parent', parent_id))
+       l.append('  * {} #{}'.format('parent', parent_id))
 
-    return "\n  * ".join(l)
+    return "\n".join(l)
 
 def changesets_to_string(changesets):
     """ Convert redmine formal changesets to some denormalized string
@@ -101,15 +93,14 @@ def changesets_to_string(changesets):
     """
     l = []
     for i in changesets:
-        #log.info(i)
         revision = i['revision']
         user = i['user']['name']
         committed_on = i['committed_on']
         comments = i['comments']
 
-        l.append('Revision {} von {} am {}:\n```\n{}\n```'.format(revision, user, committed_on, comments))
+        l.append('  * Revision {} von {} am {}:\n```\n{}\n```'.format(revision, user, committed_on, comments))
 
-    return "\n  * ".join(l)
+    return "\n".join(l)
 
 def custom_fields_to_string(custom_fields, custom_fields_include):
     """ Convert redmine custom fields to some denormalized string
@@ -119,22 +110,19 @@ def custom_fields_to_string(custom_fields, custom_fields_include):
     """
     l = []
     for i in custom_fields:
-        #log.info(i)
         name = i['name']
         
         if name in custom_fields_include and i.get('value'):
             # Name: Value
-            l.append('{}: {}'.format(name, i['value']))
+            l.append('  * {}: {}'.format(name, i['value']))
 
-    return "\n  * ".join(l)
+    return "\n".join(l)
 
 # Convertor
 
 def convert_issue(redmine_api_key, redmine_issue, redmine_user_index, gitlab_user_index,
-                  gitlab_milestones_index):
+                  gitlab_milestones_index, closed_states, custom_fields_include):
    
-    closed_states = ['closed', 'rejected', 'erledigt', 'abgewiesen']
-    custom_fields_include = ['Kunde']
     issue_state = redmine_issue['status']['name']
 
     if redmine_issue.get('closed_on', None):
@@ -148,8 +136,6 @@ def convert_issue(redmine_api_key, redmine_issue, redmine_user_index, gitlab_use
         close_text = ''
         closed = False
 
-    #log.info('issue {} {}, state: {}, closed: {}'.format(redmine_issue['id'], redmine_issue['subject'], issue_state, closed))
-
     relations = redmine_issue.get('relations', [])
     children = redmine_issue.get('children', [])
     parent_id = 0
@@ -158,17 +144,17 @@ def convert_issue(redmine_api_key, redmine_issue, redmine_user_index, gitlab_use
 
     relations_text = relations_to_string(relations, children, parent_id, redmine_issue['id'])
     if len(relations_text) > 0:
-        relations_text = "\n* Relations:\n  * " + relations_text
+        relations_text = "\n* Relations:\n" + relations_text
 
     changesets = redmine_issue.get('changesets', [])
     changesets_text = changesets_to_string(changesets)
     if len(changesets_text) > 0:
-        changesets_text = "\n* Changesets:\n  * " + changesets_text
+        changesets_text = "\n* Changesets:\n" + changesets_text
 
     custom_fields = redmine_issue.get('custom_fields', [])
     custom_fields_text = custom_fields_to_string(custom_fields, custom_fields_include)
     if len(custom_fields_text) > 0:
-        custom_fields_text = "\n* Custom Fields:\n  * " + custom_fields_text
+        custom_fields_text = "\n* Custom Fields:\n" + custom_fields_text
 
     labels = [redmine_issue['tracker']['name']]
     if (redmine_issue.get('category')):
@@ -195,8 +181,8 @@ def convert_issue(redmine_api_key, redmine_issue, redmine_user_index, gitlab_use
         data['milestone_id'] = gitlab_milestones_index[version['name']]['id']
 
     try:
-        author_login = redmine_uid_to_login(
-            redmine_issue['author']['id'], redmine_user_index)
+        author_login = redmine_uid_to_gitlab_user(
+            redmine_issue['author']['id'], redmine_user_index, gitlab_user_index)['username']
 
     except KeyError:
         log.warning(
@@ -207,15 +193,21 @@ def convert_issue(redmine_api_key, redmine_issue, redmine_user_index, gitlab_use
     meta = {
         'sudo_user': author_login,
         'notes': list(convert_notes(redmine_issue['journals'],
-                                    redmine_user_index)),
+                                    redmine_user_index, gitlab_user_index)),
         'must_close': closed,
-        'uploads': (convert_attachment(a, redmine_api_key) for a in attachments)
+        'uploads': list(convert_attachment(a, redmine_api_key) for a in attachments)
     }
 
     assigned_to = redmine_issue.get('assigned_to', None)
     if assigned_to is not None:
-        data['assignee_id'] = redmine_uid_to_gitlab_uid(
-            assigned_to['id'], redmine_user_index, gitlab_user_index)
+        try:
+            data['assignee_id'] = redmine_uid_to_gitlab_user(
+                assigned_to['id'], redmine_user_index, gitlab_user_index)['id']
+        except KeyError:
+            log.warning(
+                'Redmine issue #{} assignee is anonymous. gitlab assinee is attributed '
+                'to current admin\n'.format(redmine_issue['id']))
+
     return data, meta
 
 

--- a/redmine_gitlab_migrator/converters.py
+++ b/redmine_gitlab_migrator/converters.py
@@ -3,7 +3,6 @@
 
 import logging
 
-
 log = logging.getLogger(__name__)
 
 # Utils
@@ -18,6 +17,23 @@ def redmine_uid_to_gitlab_uid(redmine_id,
     username = redmine_uid_to_login(redmine_id, redmine_user_index)
     return gitlab_user_index[username]['id']
 
+
+def convert_attachment(redmine_issue_attachment, redmine_api_key):
+    """ Convert a list of redmine attachments to gitlab uploads
+
+    :param redmine_issue_attachment: a dict describing redmine-api-style attachment
+    :param redmine_api_key: the redmine api key used for getting the attachment without logging in
+    :return: a dict describing the attachment
+    """
+    uploads = {
+        'filename': redmine_issue_attachment['filename'],
+        'description': redmine_issue_attachment.get('description'),
+        'content_url': '{}?key={}'.format(redmine_issue_attachment['content_url'], redmine_api_key),
+        'content_type': redmine_issue_attachment['content_type']
+    }
+
+    return uploads
+    
 
 def convert_notes(redmine_issue_journals, redmine_user_index):
     """ Convert a list of redmine journal entries to gitlab notes
@@ -49,7 +65,7 @@ def convert_notes(redmine_issue_journals, redmine_user_index):
             yield {'body': body}, {'sudo_user': author}
 
 
-def relations_to_string(relations, issue_id):
+def relations_to_string(relations, children, parent_id, issue_id):
     """ Convert redmine formal relations to some denormalized string
 
     That's the way gitlab does relations, by "mentioning".
@@ -66,36 +82,112 @@ def relations_to_string(relations, issue_id):
             other_issue_id = i['issue_id']
         l.append('{} #{}'.format(i['relation_type'], other_issue_id))
 
-    return ', '.join(l)
+    for i in children:
+        id = i['id']
+        tracker = i['tracker']
+        
+        l.append('{} #{}'.format('child', id))
 
+    if parent_id > 0:
+       l.append('{} #{}'.format('parent', parent_id))
+
+    return "\n  * ".join(l)
+
+def changesets_to_string(changesets):
+    """ Convert redmine formal changesets to some denormalized string
+
+    :param changesets: list of issues changesets
+    :return a string listing changesets.
+    """
+    l = []
+    for i in changesets:
+        #log.info(i)
+        revision = i['revision']
+        user = i['user']['name']
+        committed_on = i['committed_on']
+        comments = i['comments']
+
+        l.append('Revision {} von {} am {}:\n```\n{}\n```'.format(revision, user, committed_on, comments))
+
+    return "\n  * ".join(l)
+
+def custom_fields_to_string(custom_fields, custom_fields_include):
+    """ Convert redmine custom fields to some denormalized string
+
+    :param custom_fields: list of issues custom_fields
+    :return a string listing custom_fileds.
+    """
+    l = []
+    for i in custom_fields:
+        #log.info(i)
+        name = i['name']
+        
+        if name in custom_fields_include and i.get('value'):
+            # Name: Value
+            l.append('{}: {}'.format(name, i['value']))
+
+    return "\n  * ".join(l)
 
 # Convertor
 
-def convert_issue(redmine_issue, redmine_user_index, gitlab_user_index,
+def convert_issue(redmine_api_key, redmine_issue, redmine_user_index, gitlab_user_index,
                   gitlab_milestones_index):
+   
+    closed_states = ['closed', 'rejected', 'erledigt', 'abgewiesen']
+    custom_fields_include = ['Kunde']
+    issue_state = redmine_issue['status']['name']
+
     if redmine_issue.get('closed_on', None):
         # quick'n dirty extract date
         close_text = ', closed on {}'.format(redmine_issue['closed_on'][:10])
+        closed = True
+    elif issue_state.lower() in closed_states:
+        close_text = ', closed (state: {})'.format(issue_state)
         closed = True
     else:
         close_text = ''
         closed = False
 
-    relations = redmine_issue.get('relations', [])
-    relations_text = relations_to_string(relations, redmine_issue['id'])
-    if len(relations_text) > 0:
-        relations_text = ', ' + relations_text
+    #log.info('issue {} {}, state: {}, closed: {}'.format(redmine_issue['id'], redmine_issue['subject'], issue_state, closed))
 
+    relations = redmine_issue.get('relations', [])
+    children = redmine_issue.get('children', [])
+    parent_id = 0
+    if redmine_issue.get('parent', None):
+        parent_id = redmine_issue['parent']['id']
+
+    relations_text = relations_to_string(relations, children, parent_id, redmine_issue['id'])
+    if len(relations_text) > 0:
+        relations_text = "\n* Relations:\n  * " + relations_text
+
+    changesets = redmine_issue.get('changesets', [])
+    changesets_text = changesets_to_string(changesets)
+    if len(changesets_text) > 0:
+        changesets_text = "\n* Changesets:\n  * " + changesets_text
+
+    custom_fields = redmine_issue.get('custom_fields', [])
+    custom_fields_text = custom_fields_to_string(custom_fields, custom_fields_include)
+    if len(custom_fields_text) > 0:
+        custom_fields_text = "\n* Custom Fields:\n  * " + custom_fields_text
+
+    labels = [redmine_issue['tracker']['name']]
+    if (redmine_issue.get('category')):
+        labels.append(redmine_issue['category']['name'])
+
+    attachments = redmine_issue.get('attachments', [])
+  
     data = {
         'title': '-RM-{}-MR-{}'.format(
             redmine_issue['id'], redmine_issue['subject']),
-        'description': '{}\n\n*(from redmine: created on {}{}{})*'.format(
+        'description': '{}\n\n*(from redmine: created on {}{})*\n{}{}{}'.format(
             redmine_issue['description'],
             redmine_issue['created_on'][:10],
             close_text,
-            relations_text
+            relations_text,
+            changesets_text,
+            custom_fields_text
         ),
-        'labels': [redmine_issue['tracker']['name']]
+        'labels': labels,
     }
 
     version = redmine_issue.get('fixed_version', None)
@@ -116,7 +208,8 @@ def convert_issue(redmine_issue, redmine_user_index, gitlab_user_index,
         'sudo_user': author_login,
         'notes': list(convert_notes(redmine_issue['journals'],
                                     redmine_user_index)),
-        'must_close': closed
+        'must_close': closed,
+        'uploads': (convert_attachment(a, redmine_api_key) for a in attachments)
     }
 
     assigned_to = redmine_issue.get('assigned_to', None)

--- a/redmine_gitlab_migrator/redmine.py
+++ b/redmine_gitlab_migrator/redmine.py
@@ -79,15 +79,15 @@ class RedmineProject(Project):
 
     def get_all_issues(self):
         issues = self.api.unpaginated_get(
-            '{}/issues.json?status_id=*'.format(self.public_url))
+            '{}/issues.json?status_id=*'.format(self.public_url), verify=False)
         detailed_issues = []
         # It's impossible to get issue history from list view, so get it from
         # detail view...
 
         for issue_id in (i['id'] for i in issues):
-            issue_url = '{}/issues/{}.json?include=journals,watchers,relations,childrens,attachments'.format(
+            issue_url = '{}/issues/{}.json?include=journals,watchers,relations,childrens,attachments,changesets'.format(
                 self.instance_url, issue_id)
-            detailed_issues.append(self.api.get(issue_url))
+            detailed_issues.append(self.api.get(issue_url, verify=False))
 
         return detailed_issues
 
@@ -112,7 +112,7 @@ class RedmineProject(Project):
             # The anonymous user is not really part of the project...
             if i != ANONYMOUS_USER_ID:
                 users.append(self.api.get('{}/users/{}.json'.format(
-                    self.instance_url, i)))
+                    self.instance_url, i), verify=False))
         return users
 
     def get_users_index(self):
@@ -121,5 +121,5 @@ class RedmineProject(Project):
         return {i['id']: i for i in self.get_participants()}
 
     def get_versions(self):
-        response = self.api.get('{}/versions.json'.format(self.public_url))
+        response = self.api.get('{}/versions.json'.format(self.public_url), verify=False)
         return response['versions']

--- a/redmine_gitlab_migrator/sql.py
+++ b/redmine_gitlab_migrator/sql.py
@@ -13,6 +13,11 @@ FROM issues
 WHERE title ~* '{regex}' AND project_id={project_id};
 """
 
+UPDATE_IID_ISSUES = r"""
+UPDATE issues SET
+  iid = iid * 100000
+WHERE title ~* '{regex}' AND project_id={project_id};
+"""
 
 MIGRATE_IID_ISSUES = r"""
 UPDATE issues SET

--- a/redmine_gitlab_migrator/tests/fake.py
+++ b/redmine_gitlab_migrator/tests/fake.py
@@ -163,6 +163,103 @@ class FakeGitlabClient:
         if url.endswith('/users'):
             return [JOHN, JACK]
 
+        elif url.endswith('api/v3/projects'):
+            return [{
+                "id": 3,
+                "description": None,
+                "default_branch": "master",
+                "public": False,
+                "visibility_level": 0,
+                "ssh_url_to_repo":
+                "git@example.com:diaspora/diaspora-project-site.git",
+                "http_url_to_repo":
+                "http://example.com/diaspora/diaspora-project-site.git",
+                "web_url": "http://example.com/diaspora/diaspora-project-site",
+                "tag_list": [
+                    "example",
+                    "disapora project"
+                ],
+                "owner": {
+                    "id": 3,
+                    "name": "Diaspora",
+                    "created_at": "2013-09-30T13: 46: 02Z"
+                },
+                "name": "Diaspora Project Site",
+                "name_with_namespace": "Diaspora / Diaspora Project Site",
+                "path": "diaspora-project-site",
+                "path_with_namespace": "diaspora/diaspora-project-site",
+                "issues_enabled": True,
+                "merge_requests_enabled": True,
+                "wiki_enabled": True,
+                "snippets_enabled": False,
+                "created_at": "2013-09-30T13: 46: 02Z",
+                "last_activity_at": "2013-09-30T13: 46: 02Z",
+                "creator_id": 3,
+                "namespace": {
+                    "created_at": "2013-09-30T13: 46: 02Z",
+                    "description": "",
+                    "id": 3,
+                    "name": "Diaspora",
+                    "owner_id": 1,
+                    "path": "diaspora",
+                    "updated_at": "2013-09-30T13: 46: 02Z"
+                },
+                "permissions": {
+                    "project_access": {
+                        "access_level": 10,
+                        "notification_level": 3
+                    },
+                    "group_access": {
+                        "access_level": 50,
+                        "notification_level": 3
+                    }
+                },
+                "archived": False,
+                "avatar_url":
+                "http://example.com/uploads/project/avatar/3/uploads/avr.png"
+            },
+            {
+                "id": 6,
+                "description": None,
+                "default_branch": None,
+                "public": False,
+                "visibility_level": 0,
+                "ssh_url_to_repo": "git@example.com:brightbox/puppet.git",
+                "http_url_to_repo": "http://example.com/brightbox/puppet.git",
+                "web_url": "http://example.com/brightbox/puppet",
+                "tag_list": [
+                    "example",
+                    "puppet"
+                ],
+                "owner": {
+                    "id": 4,
+                    "name": "Brightbox",
+                    "created_at": "2013-09-30T13:46:02Z"
+                },
+                "name": "Puppet",
+                "name_with_namespace": "Brightbox / Puppet",
+                "path": "puppet",
+                "path_with_namespace": "brightbox/puppet",
+                "issues_enabled": True,
+                "merge_requests_enabled": True,
+                "wiki_enabled": True,
+                "snippets_enabled": False,
+                "created_at": "2013-09-30T13:46:02Z",
+                "last_activity_at": "2013-09-30T13:46:02Z",
+                "creator_id": 3,
+                "namespace": {
+                    "created_at": "2013-09-30T13:46:02Z",
+                    "description": "",
+                    "id": 4,
+                    "name": "Brightbox",
+                    "owner_id": 1,
+                    "path": "brightbox",
+                    "updated_at": "2013-09-30T13:46:02Z"
+                },
+                "archived": False,
+                "avatar_url": None
+            }]
+
         elif (url.endswith('/projects/3') or
               url.endswith('/projects/diaspora%2Fdiaspora-project-site')):
             return {
@@ -220,7 +317,8 @@ class FakeGitlabClient:
                 "http://example.com/uploads/project/avatar/3/uploads/avr.png"
             }
 
-        elif url.endswith('/projects/diaspora%2Fdiaspora-project-site/issues'):
+        elif (url.endswith('/projects/3/issues') or
+              url.endswith('/projects/diaspora%2Fdiaspora-project-site/issues')):
             return [
                 {
                     "id": 43,
@@ -283,8 +381,8 @@ class FakeGitlabClient:
                 }
             ]
 
-        elif url.endswith(
-                '/projects/diaspora%2Fdiaspora-project-site/members'):
+        elif (url.endswith('/projects/3/members') or
+              url.endswith('/projects/diaspora%2Fdiaspora-project-site/members')):
             return [JACK, JOHN]
 
         elif (url.endswith('/projects/6') or
@@ -330,10 +428,12 @@ class FakeGitlabClient:
                 "archived": False,
                 "avatar_url": None
             }
-        elif url.endswith('/projects/brightbox%2Fpuppet/issues'):
+        elif (url.endswith('/projects/6/issues') or
+              url.endswith('/projects/brightbox%2Fpuppet/issues')):
             return []
 
-        elif url.endswith('/projects/brightbox%2Fpuppet/members'):
+        elif (orl.endswith('/projects/6/members') or	
+              url.endswith('/projects/brightbox%2Fpuppet/members')):
             return []
 
         else:
@@ -430,6 +530,7 @@ class FakeRedmineClient:
             raise ValueError('{} is unknown data test'.format(url))
 
     def get(self, url):
+
         if url.endswith('projects/brightbox/puppet.json'):
             return {
                 "project": {

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except IOError:
 
 setup(
     name='redmine-gitlab-migrator',
-    version='1.0.2',
+    version='1.0.3',
     description='Migrate a redmine project to gitlab',
     long_description=README,
     author='Jocelyn Delalande',


### PR DESCRIPTION
* works with current gitlab (query projectId from namespace and project
name for api url)
* works with self signed certificates
* imports closed state based on redmine status as fallback (see:
converters.py closed_states)
* imports predefined custom fields (see: converters.py
custom_fields_include)
* imports related issue changesets
* imports related children and parent
* imports category as labels
* imports attachments

tested with redmine 2.1.2 and gitlab 8.11